### PR TITLE
Run deploy pages workflow on any push

### DIFF
--- a/.github/workflows/deploy-page.yml
+++ b/.github/workflows/deploy-page.yml
@@ -2,8 +2,6 @@ name: Deploy page
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #30

Update deploy pages workflow to run on any push

* Remove the `branches` key under the `push` event in `.github/workflows/deploy-page.yml` to allow the workflow to run on any push

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/31?shareId=eb63253a-7b52-4e79-b8ec-ba9e2a8bcd78).