### PR TITLE
Synchronize scoreboard object with other players

### DIFF
--- a/src/models/object-type.ts
+++ b/src/models/object-type.ts
@@ -1,4 +1,5 @@
 export enum ObjectType {
   Ball = 0,
   RemoteCar = 1,
+  Scoreboard = 2,
 }

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -66,6 +66,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
   private addSyncableObjects(): void {
     this.addSyncableObject(BallObject);
     this.addSyncableObject(RemoteCarObject);
+    this.addSyncableObject(ScoreboardObject);
   }
 
   private createBackgroundObject() {
@@ -229,6 +230,14 @@ export class WorldScreen extends BaseCollidingGameScreen {
     this.goalTimerService = this.gameController.addTimer(5, () =>
       this.handleGoalTimerEnd()
     );
+
+    // Synchronize scoreboard
+    if (this.gameState.getGamePlayer().isHost()) {
+      const data = this.scoreboardObject?.serialize();
+      if (data) {
+        this.gameController.getObjectOrchestrator().sendSyncableData(data);
+      }
+    }
   }
 
   private handlePlayerScore(player: GamePlayer) {


### PR DESCRIPTION
Fixes #32

Synchronize the scoreboard object with other players by implementing serialization and synchronization methods.

* **ScoreboardObject**:
  - Implement `serialize` method to convert `blueScore`, `redScore`, and `remainingTimeSeconds` to an `ArrayBuffer`.
  - Implement `synchronize` method to update `blueScore`, `redScore`, and `remainingTimeSeconds` from an `ArrayBuffer`.
  - Add `setSyncableValues` method to set syncable properties like `syncableId` and `objectTypeId`.
  - Call `setSyncableValues` in the constructor to initialize syncable properties.
  - Update `render` method to use `remainingTimeSeconds` for displaying the time.

* **WorldScreen**:
  - Add `ScoreboardObject` to the list of syncable objects in `addSyncableObjects` method.
  - Update `handleGoalScored` method to synchronize the scoreboard after updating scores.

* **ObjectType**:
  - Add `Scoreboard` to the `ObjectType` enum.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/33?shareId=682973b6-998d-47d5-a403-190137c98823).