### PR TITLE
Override mustSync method for ball and car objects

### DIFF
--- a/src/objects/ball-object.ts
+++ b/src/objects/ball-object.ts
@@ -229,4 +229,8 @@ export class BallObject
     context.textAlign = "left";
     context.fillText(`Last Touch: ${playerName}`, 30, 110);
   }
+
+  public override mustSync(): boolean {
+    return this.vx !== 0 || this.vy !== 0;
+  }
 }

--- a/src/objects/car-object.ts
+++ b/src/objects/car-object.ts
@@ -172,4 +172,8 @@ export class CarObject extends BaseDynamicCollidableGameObject {
     this.x -= this.vx;
     this.y -= this.vy;
   }
+
+  public override mustSync(): boolean {
+    return this.speed !== 0;
+  }
 }


### PR DESCRIPTION
Fixes #40

Override the `mustSync` method in `BallObject` and `CarObject` classes to return true when they are moving.

* In `src/objects/ball-object.ts`, override the `mustSync` method to return true when `vx` or `vy` is not zero.
* In `src/objects/car-object.ts`, override the `mustSync` method to return true when `speed` is not zero.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/41?shareId=ced8a651-c505-4f2a-8e38-c6e4de2fea0a).