### PR TITLE
Calculate scoreboard remaining time in seconds on update

### DIFF
--- a/src/objects/scoreboard-object.ts
+++ b/src/objects/scoreboard-object.ts
@@ -32,6 +32,7 @@ export class ScoreboardObject extends BaseGameObject {
   private active: boolean = false;
   private elapsedMilliseconds: number = 0;
   private durationMilliseconds: number = 0;
+  private remainingSeconds: number = 0;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();
@@ -44,6 +45,9 @@ export class ScoreboardObject extends BaseGameObject {
       if (this.elapsedMilliseconds >= this.durationMilliseconds) {
         this.stopCountdown();
       }
+      this.remainingSeconds = Math.ceil(
+        (this.durationMilliseconds - this.elapsedMilliseconds) / 1000
+      );
     }
   }
 
@@ -53,10 +57,7 @@ export class ScoreboardObject extends BaseGameObject {
     const startX = this.x - totalWidth / 2;
 
     this.renderSquare(context, startX, this.BLUE_SHAPE_COLOR, this.blueScore);
-    const remainingTimeSeconds = Math.ceil(
-      (this.durationMilliseconds - this.elapsedMilliseconds) / 1000
-    );
-    const formattedTime = this.formatTime(remainingTimeSeconds);
+    const formattedTime = this.formatTime(this.remainingSeconds);
     const timeX = startX + this.SQUARE_SIZE + this.SPACE_BETWEEN;
     const timeY = this.y + (this.SQUARE_SIZE - this.TIME_BOX_HEIGHT) / 2;
     this.renderTimeBox(


### PR DESCRIPTION
Fixes #42

Add `remainingSeconds` property to store the remaining time in seconds and update the `update` and `render` methods to use it.

* **Add `remainingSeconds` property**
  - Add a `remainingSeconds` property to the `Scoreboard` class to store the remaining time in seconds.

* **Update `update` method**
  - Calculate the remaining time in seconds and store it in the `remainingSeconds` property.

* **Update `render` method**
  - Use the `remainingSeconds` property instead of calculating the remaining time.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/43?shareId=2011bad2-b8a8-4431-bd6c-6be7581aa126).