### PR TITLE
Fix scoreboard synchronization

### DIFF
--- a/src/objects/scoreboard-object.ts
+++ b/src/objects/scoreboard-object.ts
@@ -100,8 +100,6 @@ export class ScoreboardObject
   }
 
   public synchronize(data: ArrayBuffer): void {
-    this.active = true;
-
     const dataView = new DataView(data);
     this.elapsedMilliseconds = dataView.getInt32(0);
   }


### PR DESCRIPTION
Fixes #56

Remove the line that sets `active` to `true` in the `synchronize` method of `src/objects/scoreboard-object.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/57?shareId=978d5e34-ef65-401a-bab8-46a7fae17512).