### PR TITLE
Add message queue to WebRTC peer service

### DIFF
--- a/src/services/interfaces/webrtc-peer.ts
+++ b/src/services/interfaces/webrtc-peer.ts
@@ -18,8 +18,8 @@ export interface WebRTCPeer {
   connect(answer: RTCSessionDescriptionInit): Promise<void>;
   getQueuedIceCandidates(): RTCIceCandidateInit[];
   addRemoteIceCandidate(iceCandidate: RTCIceCandidateInit): void;
-  sendReliableOrderedMessage(arrayBuffer: ArrayBuffer): void;
-  sendReliableUnorderedMessage(arrayBuffer: ArrayBuffer): void;
-  sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer): void;
-  sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer): void;
+  sendReliableOrderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
+  sendReliableUnorderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
+  sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
+  sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
 }

--- a/src/services/matchmaking-service.ts
+++ b/src/services/matchmaking-service.ts
@@ -389,7 +389,7 @@ export class MatchmakingService {
       ...playerNameBytes,
     ]);
 
-    peer.sendReliableUnorderedMessage(payload);
+    peer.sendReliableUnorderedMessage(payload, true);
   }
 
   private handleUnavailableSlots(peer: WebRTCPeer): void {
@@ -403,7 +403,7 @@ export class MatchmakingService {
     const payload = new Uint8Array([JOIN_RESPONSE_ID, state, totalSlots]);
 
     console.log("Sending join response to", peer.getName());
-    peer.sendReliableOrderedMessage(payload);
+    peer.sendReliableOrderedMessage(payload, true);
 
     this.sendPlayerList(peer);
     this.sendSnapshot(peer);
@@ -449,19 +449,19 @@ export class MatchmakingService {
       ...nameBytes,
     ]);
 
-    peer.sendReliableOrderedMessage(payload);
+    peer.sendReliableOrderedMessage(payload, true);
   }
 
   private sendSnapshot(peer: WebRTCPeer): void {
     console.log("Sending snapshot to", peer.getName());
 
     const payload = new Uint8Array([SNAPSHOT_ID]);
-    peer.sendReliableOrderedMessage(payload);
+    peer.sendReliableOrderedMessage(payload, true);
   }
 
   private sentSnapshotACK(peer: WebRTCPeer): void {
     console.log("Sending snapshot ACK to", peer.getName());
     const payload = new Uint8Array([SNAPSHOT_ACK_ID]);
-    peer.sendReliableOrderedMessage(payload);
+    peer.sendReliableOrderedMessage(payload, true);
   }
 }


### PR DESCRIPTION
Fixes #58

Add message queue and skip queue parameter to WebRTC peer service.

* Add a message queue to the `WebRTCPeerService` class.
* Modify the `sendMessage` methods to include a `skipQueue` parameter.
* Queue messages if the peer has not joined and `skipQueue` is `false`.
* Send queued messages when the peer's `joined` status changes to `true`.
* Update `sendReliableUnorderedMessage`, `sendReliableOrderedMessage`, `sendUnreliableOrderedMessage`, and `sendUnreliableUnorderedMessage` methods to include `skipQueue` parameter.
* Update `matchmaking-service.ts` to use `skipQueue` parameter with `true` value in `sendReliableUnorderedMessage` and `sendReliableOrderedMessage` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/59?shareId=950c35ad-e2a1-4aae-b5d3-9a628c70e6a9).