### PR TITLE
Only queue messages that are reliable

### DIFF
--- a/src/services/interfaces/webrtc-peer.ts
+++ b/src/services/interfaces/webrtc-peer.ts
@@ -20,6 +20,6 @@ export interface WebRTCPeer {
   addRemoteIceCandidate(iceCandidate: RTCIceCandidateInit): void;
   sendReliableOrderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
   sendReliableUnorderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
-  sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
-  sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer, skipQueue?: boolean): void;
+  sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer): void;
+  sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer): void;
 }

--- a/src/services/webrtc-peer-service.ts
+++ b/src/services/webrtc-peer-service.ts
@@ -146,12 +146,18 @@ export class WebRTCPeerService {
     this.sendMessage("reliable-unordered", arrayBuffer, skipQueue);
   }
 
-  public sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer, skipQueue = false): void {
-    this.sendMessage("unreliable-ordered", arrayBuffer, skipQueue);
+  public sendUnreliableOrderedMessage(arrayBuffer: ArrayBuffer): void {
+    if (!this.joined) {
+      return;
+    }
+    this.sendMessage("unreliable-ordered", arrayBuffer, true);
   }
 
-  public sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer, skipQueue = false): void {
-    this.sendMessage("unreliable-unordered", arrayBuffer, skipQueue);
+  public sendUnreliableUnorderedMessage(arrayBuffer: ArrayBuffer): void {
+    if (!this.joined) {
+      return;
+    }
+    this.sendMessage("unreliable-unordered", arrayBuffer, true);
   }
 
   private initializeDataChannels(): void {


### PR DESCRIPTION
Fixes #60

Remove the `skipQueue` argument from `sendUnreliableOrderedMessage` and `sendUnreliableUnorderedMessage` methods in `src/services/interfaces/webrtc-peer.ts`.

Update `sendUnreliableOrderedMessage` and `sendUnreliableUnorderedMessage` methods in `src/services/webrtc-peer-service.ts` to discard messages if the peer is not joined.
* Add a check for the `joined` status before sending unreliable messages.
* Call `sendMessage` with `true` for the `skipQueue` argument for unreliable messages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/61?shareId=524ec9db-3e80-4138-a770-3165155c79ce).