### PR TITLE
Add getRanking function to API service

### DIFF
--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -21,3 +21,4 @@ export const MATCHES_REMOVE_ENDPOINT = "/matches/remove";
 
 export const SCOREBOARD_PATH = "/scoreboard";
 export const SCOREBOARD_SAVE_SCORE_PATH = `${SCOREBOARD_PATH}/saveScore`;
+export const SCOREBOARD_GET_RANKING_PATH = `${SCOREBOARD_PATH}/getRanking`;

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -8,6 +8,7 @@ import {
   REGISTER_ENDPOINT,
   VERSION_ENDPOINT,
   SCOREBOARD_SAVE_SCORE_PATH,
+  SCOREBOARD_GET_RANKING_PATH,
 } from "../constants/api-constants.js";
 import { AdvertiseMatchRequest } from "./interfaces/request/advertise-match-request.js";
 import { FindMatchRequest as FindMatchesRequest } from "./interfaces/request/find-matches-request.js";
@@ -16,6 +17,7 @@ import { MessagesResponse } from "./interfaces/response/messages-response.js";
 import { RegistrationResponse } from "./interfaces/response/registration-response.js";
 import { VersionResponse } from "./interfaces/response/version-response.js";
 import { SaveScoreRequest } from "./interfaces/request/save-score-request.js";
+import { RankingResponse } from "./interfaces/response/ranking-response.js";
 import { CryptoService } from "./crypto-service.js";
 import { GameController } from "../models/game-controller.js";
 
@@ -205,5 +207,26 @@ export class ApiService {
     }
 
     console.log("Score saved");
+  }
+
+  public async getRanking(): Promise<RankingResponse[]> {
+    if (this.authenticationToken === null) {
+      throw new Error("Authentication token not found");
+    }
+
+    const response = await fetch(API_BASE_URL + SCOREBOARD_GET_RANKING_PATH, {
+      headers: {
+        Authorization: this.authenticationToken,
+      },
+    });
+
+    if (response.ok === false) {
+      throw new Error("Failed to fetch ranking");
+    }
+
+    const rankingResponse: RankingResponse[] = await response.json();
+    console.log("Ranking response", rankingResponse);
+
+    return rankingResponse;
   }
 }

--- a/src/services/interfaces/response/ranking-response.ts
+++ b/src/services/interfaces/response/ranking-response.ts
@@ -1,0 +1,4 @@
+export interface RankingResponse {
+  player_name: string;
+  total_score: number;
+}


### PR DESCRIPTION
Fixes #64

Add getRanking function to API service.

* Add `SCOREBOARD_GET_RANKING_PATH` constant to `src/constants/api-constants.ts`.
* Define `RankingResponse` interface in `src/services/interfaces/response/ranking-response.ts`.
* Implement `getRanking` function in `ApiService` class in `src/services/api-service.ts` to fetch data from `SCOREBOARD_GET_RANKING_PATH` and return `RankingResponse[]`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/65?shareId=e199a024-4e6a-4e4b-929a-795b169efe1a).