### PR TITLE
Add scoreboard screen

### DIFF
--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -8,6 +8,7 @@ import { MessagesResponse } from "../../services/interfaces/response/messages-re
 import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { LoadingScreen } from "./loading-screen.js";
+import { ScoreboardScreen } from "../scoreboard-screen.js";
 
 export class MainMenuScreen extends BaseGameScreen {
   private MENU_OPTIONS_TEXT: string[] = ["Join game", "Scoreboard", "Settings"];
@@ -156,7 +157,8 @@ export class MainMenuScreen extends BaseGameScreen {
         break;
 
       case 1:
-        return this.closeableMessageObject?.show("Not implemented");
+        this.transitionToScoreboardScreen();
+        break;
 
       case 2:
         return this.closeableMessageObject?.show("Not implemented");
@@ -177,5 +179,18 @@ export class MainMenuScreen extends BaseGameScreen {
     loadingScreen.loadObjects();
 
     this.transitionService.crossfade(loadingScreen, 0.2);
+  }
+
+  private transitionToScoreboardScreen(): void {
+    this.uiObjects.forEach((uiObject) => {
+      if (uiObject instanceof MenuOptionObject) {
+        uiObject.setActive(false);
+      }
+    });
+
+    const scoreboardScreen = new ScoreboardScreen(this.gameController);
+    scoreboardScreen.loadObjects();
+
+    this.transitionService.crossfade(scoreboardScreen, 0.2);
   }
 }

--- a/src/screens/scoreboard-screen.ts
+++ b/src/screens/scoreboard-screen.ts
@@ -59,4 +59,9 @@ export class ScoreboardScreen extends BaseGameScreen {
       startY += 30;
     });
   }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    this.renderTable();
+    super.render(context);
+  }
 }

--- a/src/screens/scoreboard-screen.ts
+++ b/src/screens/scoreboard-screen.ts
@@ -2,6 +2,7 @@ import { BaseGameScreen } from "./base/base-game-screen.js";
 import { TitleObject } from "../objects/common/title-object.js";
 import { ApiService } from "../services/api-service.js";
 import { RankingResponse } from "../services/interfaces/response/ranking-response.js";
+import { GameController } from "../models/game-controller.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject;

--- a/src/screens/scoreboard-screen.ts
+++ b/src/screens/scoreboard-screen.ts
@@ -1,0 +1,61 @@
+import { BaseGameScreen } from "./base/base-game-screen.js";
+import { TitleObject } from "../objects/common/title-object.js";
+import { ApiService } from "../services/api-service.js";
+import { RankingResponse } from "../services/interfaces/response/ranking-response.js";
+
+export class ScoreboardScreen extends BaseGameScreen {
+  private titleObject: TitleObject;
+  private ranking: RankingResponse[] = [];
+
+  constructor(gameController: GameController) {
+    super(gameController);
+    this.titleObject = new TitleObject();
+    this.titleObject.setText("Scoreboard");
+  }
+
+  public override loadObjects(): void {
+    this.uiObjects.push(this.titleObject);
+    super.loadObjects();
+  }
+
+  public override hasTransitionFinished(): void {
+    super.hasTransitionFinished();
+    this.fetchRanking();
+  }
+
+  private fetchRanking(): void {
+    const apiService = this.gameController.getApiService();
+    apiService.getRanking().then((ranking) => {
+      this.ranking = ranking;
+      this.renderTable();
+    }).catch((error) => {
+      console.error("Failed to fetch ranking", error);
+    });
+  }
+
+  private renderTable(): void {
+    const context = this.canvas.getContext("2d");
+    if (!context) return;
+
+    context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.titleObject.render(context);
+
+    context.fillStyle = "white";
+    context.font = "lighter 20px system-ui";
+    context.textAlign = "left";
+
+    const startX = 30;
+    let startY = 100;
+
+    context.fillText("Player Name", startX, startY);
+    context.fillText("Score", startX + 200, startY);
+
+    startY += 30;
+
+    this.ranking.forEach((player) => {
+      context.fillText(player.player_name, startX, startY);
+      context.fillText(player.total_score.toString(), startX + 200, startY);
+      startY += 30;
+    });
+  }
+}

--- a/src/screens/scoreboard-screen.ts
+++ b/src/screens/scoreboard-screen.ts
@@ -11,7 +11,7 @@ export class ScoreboardScreen extends BaseGameScreen {
   constructor(gameController: GameController) {
     super(gameController);
     this.titleObject = new TitleObject();
-    this.titleObject.setText("Scoreboard");
+    this.titleObject.setText("SCOREBOARD");
   }
 
   public override loadObjects(): void {


### PR DESCRIPTION
Fixes #66

Add a new scoreboard screen to display player rankings.

* **ScoreboardScreen Class**
  - Create `ScoreboardScreen` class extending `BaseGameScreen`.
  - Add `TitleObject` to display the title "Scoreboard".
  - Implement `loadObjects` method to load the title and table.
  - Fetch ranking data from API service on transition finished.
  - Render a table with player names and scores on the canvas.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/67?shareId=1566286c-6594-4f42-94c3-0053290ba5bf).