### PR TITLE
Use screen manager service for scoreboard

### DIFF
--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -191,6 +191,6 @@ export class MainMenuScreen extends BaseGameScreen {
     const scoreboardScreen = new ScoreboardScreen(this.gameController);
     scoreboardScreen.loadObjects();
 
-    this.transitionService.crossfade(scoreboardScreen, 0.2);
+    this.screenManagerService?.getTransitionService().crossfade(scoreboardScreen, 0.2); // Pab34 // P6d3c
   }
 }


### PR DESCRIPTION
Fixes #68

Update the `transitionToScoreboardScreen` method in `src/screens/main-screen/main-menu-screen.ts` to use `screenManagerService` for the transition.

* Set the crossfade duration to 0.2 seconds in the `transitionToScoreboardScreen` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/69?shareId=de3651f6-dc5a-453a-bd1b-c9f88da3b957).