### PR TITLE
Remove headers from scoreboard table

### DIFF
--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -58,12 +58,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     context.textAlign = "left";
 
     const startX = 30;
-    let startY = 100;
-
-    context.fillText("Player Name", startX, startY);
-    context.fillText("Score", startX + 200, startY);
-
-    startY += 30;
+    let startY = 70; // P62db
 
     this.ranking.forEach((player) => {
       context.fillText(player.player_name, startX, startY);

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -58,7 +58,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     context.textAlign = "left";
 
     const startX = 30;
-    let startY = 70; // P62db
+    let startY = 100;
 
     this.ranking.forEach((player) => {
       context.fillText(player.player_name, startX, startY);


### PR DESCRIPTION
Fixes #70

Remove player name and score headers from the scoreboard table.

* Remove the headers "Player Name" and "Score" from the `renderTable` method.
* Adjust the `startY` variable initialization to remove the space for headers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/71?shareId=abfa5757-fb30-4fee-873a-ed90277ccda0).