### PR TITLE
Improve scoreboard screen

### DIFF
--- a/src/objects/scoreboard-object.ts
+++ b/src/objects/scoreboard-object.ts
@@ -18,7 +18,7 @@ export class ScoreboardObject
   private readonly CORNER_RADIUS: number = 10;
 
   private readonly TEXT_COLOR: string = "white";
-  private readonly FONT_SIZE: string = "32px";
+  private readonly FONT_SIZE: string = "36px";
   private readonly FONT_FAMILY: string = "monospace";
 
   private readonly TIME_TEXT_COLOR: string = "white";

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -62,7 +62,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     this.ranking.forEach((player, index) => {
       context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
       context.fillText(player.player_name, startX, startY);
-      context.fillText(player.total_score.toString(), this.canvas.width - 20, startY);
+      context.fillText(player.total_score.toString(), this.canvas.width - 40, startY);
       startY += 30;
     });
   }

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -53,14 +53,14 @@ export class ScoreboardScreen extends BaseGameScreen {
   }
 
   private renderTable(context: CanvasRenderingContext2D): void {
-    context.fillStyle = "white";
-    context.font = "lighter 20px system-ui";
+    context.font = "lighter 24px system-ui";
     context.textAlign = "left";
 
     const startX = 30;
     let startY = 100;
 
-    this.ranking.forEach((player) => {
+    this.ranking.forEach((player, index) => {
+      context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
       context.fillText(player.player_name, startX, startY);
       context.fillText(player.total_score.toString(), startX + 200, startY);
       startY += 30;

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -62,7 +62,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     this.ranking.forEach((player, index) => {
       context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
       context.fillText(player.player_name, startX, startY);
-      context.fillText(player.total_score.toString(), this.canvas.width - 10, startY);
+      context.fillText(player.total_score.toString(), this.canvas.width - 20, startY);
       startY += 30;
     });
   }

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -62,7 +62,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     this.ranking.forEach((player, index) => {
       context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
       context.fillText(player.player_name, startX, startY);
-      context.fillText(player.total_score.toString(), startX + 200, startY);
+      context.fillText(player.total_score.toString(), this.canvas.width - 230, startY);
       startY += 30;
     });
   }

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -62,7 +62,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     this.ranking.forEach((player, index) => {
       context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
       context.fillText(player.player_name, startX, startY);
-      context.fillText(player.total_score.toString(), this.canvas.width - 230, startY);
+      context.fillText(player.total_score.toString(), this.canvas.width - 10, startY);
       startY += 30;
     });
   }


### PR DESCRIPTION
Fixes #72

Increase font size for player name and score, and make alternate rows text color slightly gray on the scoreboard screen.

* Increase font size for player name and score from `32px` to `36px` in `src/objects/scoreboard-object.ts`.
* Make alternate rows text color slightly gray and increase font size in `renderTable` method of `src/screens/main-screen/scoreboard-screen.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/73?shareId=b71457ab-1ec4-4518-b431-c683899e707a).