### PR TITLE
Main menu screen must enable menu buttons on transition finished

### DIFF
--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -39,6 +39,7 @@ export class MainMenuScreen extends BaseGameScreen {
 
   public override hasTransitionFinished(): void {
     super.hasTransitionFinished();
+    this.enableMenuButtons();
 
     if (this.showNews) {
       this.downloadServerMessages();
@@ -170,11 +171,7 @@ export class MainMenuScreen extends BaseGameScreen {
   }
 
   private transitionToLoadingScreen(): void {
-    this.uiObjects.forEach((uiObject) => {
-      if (uiObject instanceof MenuOptionObject) {
-        uiObject.setActive(false);
-      }
-    });
+    this.disableMenuButtons();
 
     const loadingScreen = new LoadingScreen(this.gameController);
     loadingScreen.loadObjects();
@@ -183,17 +180,29 @@ export class MainMenuScreen extends BaseGameScreen {
   }
 
   private transitionToScoreboardScreen(): void {
-    this.uiObjects.forEach((uiObject) => {
-      if (uiObject instanceof MenuOptionObject) {
-        uiObject.setActive(false);
-      }
-    });
+    this.disableMenuButtons();
 
     const scoreboardScreen = new ScoreboardScreen(this.gameController);
     scoreboardScreen.loadObjects();
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(scoreboardScreen, 0.2); // Pab34 // P6d3c
+      .crossfade(scoreboardScreen, 0.2);
+  }
+
+  private enableMenuButtons(): void {
+    this.uiObjects.forEach((uiObject) => {
+      if (uiObject instanceof MenuOptionObject) {
+        uiObject.setActive(true);
+      }
+    });
+  }
+
+  private disableMenuButtons(): void {
+    this.uiObjects.forEach((uiObject) => {
+      if (uiObject instanceof MenuOptionObject) {
+        uiObject.setActive(false);
+      }
+    });
   }
 }


### PR DESCRIPTION
Fixes #74

Add methods to enable and disable menu buttons in `MainMenuScreen`.

* Add `enableMenuButtons` method to enable menu buttons.
* Add `disableMenuButtons` method to disable menu buttons.
* Call `enableMenuButtons` in `hasTransitionFinished` method.
* Refactor code to disable buttons into `disableMenuButtons` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/75?shareId=450c4693-9515-4585-88a9-52fa5c6ee65a).