### PR TITLE
Reset scoreboard countdown on transition finished

### DIFF
--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -64,6 +64,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
 
     this.toastObject?.show("Finding sessions...");
     this.gameController.getMatchmakingService().findOrAdvertiseMatch();
+    this.scoreboardObject?.reset(); // P58a2
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {


### PR DESCRIPTION
Fixes #80

Reset the scoreboard countdown when the world screen transition finishes.

* Call the `reset` method of the `ScoreboardObject` in the `hasTransitionFinished` method of `src/screens/world-screen.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/81?shareId=902e26fc-f39e-453b-bb92-f519ac4a5a37).