### PR TITLE
Change scoreboard row text colors

### DIFF
--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -5,6 +5,7 @@ import { TitleObject } from "../../objects/common/title-object.js";
 import { RankingResponse } from "../../services/interfaces/response/ranking-response.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
+import { BLUE_TEAM_COLOR, RED_TEAM_COLOR } from "../../constants/colors-constants.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
@@ -69,7 +70,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     let startY = 100;
 
     this.ranking.forEach((player, index) => {
-      context.fillStyle = index % 2 === 0 ? "white" : "lightgray";
+      context.fillStyle = index % 2 === 0 ? BLUE_TEAM_COLOR : RED_TEAM_COLOR;
       context.fillText(player.player_name, startX, startY);
       context.fillText(player.total_score.toString(), this.canvas.width - 40, startY);
       startY += 30;


### PR DESCRIPTION
Fixes #82

Update scoreboard row text colors to team colors

* Import `BLUE_TEAM_COLOR` and `RED_TEAM_COLOR` from `src/constants/colors-constants.js`
* Update `renderTable` method to set row text color to `BLUE_TEAM_COLOR` for even rows and `RED_TEAM_COLOR` for odd rows

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/83?shareId=1ecbd11e-414f-43f2-8c38-fa971b87382b).