### PR TITLE
Use white and slightly grey for scoreboard text rows

### DIFF
--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -5,7 +5,6 @@ import { TitleObject } from "../../objects/common/title-object.js";
 import { RankingResponse } from "../../services/interfaces/response/ranking-response.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
-import { BLUE_TEAM_COLOR, RED_TEAM_COLOR } from "../../constants/colors-constants.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
@@ -70,7 +69,7 @@ export class ScoreboardScreen extends BaseGameScreen {
     let startY = 100;
 
     this.ranking.forEach((player, index) => {
-      context.fillStyle = index % 2 === 0 ? BLUE_TEAM_COLOR : RED_TEAM_COLOR;
+      context.fillStyle = index % 2 === 0 ? "white" : "#f0f0f0";
       context.fillText(player.player_name, startX, startY);
       context.fillText(player.total_score.toString(), this.canvas.width - 40, startY);
       startY += 30;


### PR DESCRIPTION
Fixes #84

Update the scoreboard text color for alternate rows to white and slightly grey.

* Remove the import of `BLUE_TEAM_COLOR` and `RED_TEAM_COLOR` from `src/screens/main-screen/scoreboard-screen.ts`.
* Set the text color to `white` for even rows and `#f0f0f0` for odd rows in the `renderTable` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/85?shareId=fb41d415-39a5-4066-9a68-52c26e4843a7).