### PR TITLE
Improve ranking table

### DIFF
--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -19,10 +19,21 @@ export class RankingTableObject extends BaseAnimatedGameObject {
     let startY = 100;
 
     this.ranking.forEach((player, index) => {
-      context.fillStyle = index % 2 === 0 ? "white" : "#BDBDBD";
-      context.fillText(player.player_name, startX, startY);
+      context.fillStyle = "white";
+      context.fillText(`#${index + 1}`, startX, startY);
+      context.fillText(player.player_name, startX + 50, startY);
       context.fillText(player.total_score.toString(), context.canvas.width - 40, startY);
       startY += 30;
+
+      // Draw dashed line between rows
+      if (index < this.ranking.length - 1) {
+        context.strokeStyle = "#BDBDBD";
+        context.setLineDash([5, 5]);
+        context.beginPath();
+        context.moveTo(startX, startY - 15);
+        context.lineTo(context.canvas.width - 30, startY - 15);
+        context.stroke();
+      }
     });
 
     context.restore();


### PR DESCRIPTION
Fixes #88

Add ranking position column and dashed lines to ranking table

* Add a column before the player name to show `#1`, `#2` depending on ranking position starting from `#1`.
* Add dashed line between each row in the ranking table.
* Remove alternate color for rows.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/89?shareId=ec12a689-f768-43c9-b0b3-65b986bc8fc6).