### PR TITLE
Improve spacing between ranking rows

### DIFF
--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -30,8 +30,8 @@ export class RankingTableObject extends BaseAnimatedGameObject {
         context.strokeStyle = "#BDBDBD";
         context.setLineDash([5, 5]);
         context.beginPath();
-        context.moveTo(startX, startY - 25);
-        context.lineTo(context.canvas.width - 30, startY - 25);
+        context.moveTo(startX, startY - 22.5);
+        context.lineTo(context.canvas.width - 30, startY - 22.5);
         context.stroke();
       }
     });

--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -30,8 +30,8 @@ export class RankingTableObject extends BaseAnimatedGameObject {
         context.strokeStyle = "#BDBDBD";
         context.setLineDash([5, 5]);
         context.beginPath();
-        context.moveTo(startX, startY - 22.5);
-        context.lineTo(context.canvas.width - 30, startY - 22.5);
+        context.moveTo(startX, startY - 27.5);
+        context.lineTo(context.canvas.width - 30, startY - 27.5);
         context.stroke();
       }
     });

--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -30,8 +30,8 @@ export class RankingTableObject extends BaseAnimatedGameObject {
         context.strokeStyle = "#BDBDBD";
         context.setLineDash([5, 5]);
         context.beginPath();
-        context.moveTo(startX, startY - 20);
-        context.lineTo(context.canvas.width - 30, startY - 20);
+        context.moveTo(startX, startY - 30);
+        context.lineTo(context.canvas.width - 30, startY - 30);
         context.stroke();
       }
     });

--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -30,8 +30,8 @@ export class RankingTableObject extends BaseAnimatedGameObject {
         context.strokeStyle = "#BDBDBD";
         context.setLineDash([5, 5]);
         context.beginPath();
-        context.moveTo(startX, startY - 30);
-        context.lineTo(context.canvas.width - 30, startY - 30);
+        context.moveTo(startX, startY - 25);
+        context.lineTo(context.canvas.width - 30, startY - 25);
         context.stroke();
       }
     });

--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -23,15 +23,15 @@ export class RankingTableObject extends BaseAnimatedGameObject {
       context.fillText(`#${index + 1}`, startX, startY);
       context.fillText(player.player_name, startX + 50, startY);
       context.fillText(player.total_score.toString(), context.canvas.width - 40, startY);
-      startY += 30;
+      startY += 40;
 
       // Draw dashed line between rows
       if (index < this.ranking.length - 1) {
         context.strokeStyle = "#BDBDBD";
         context.setLineDash([5, 5]);
         context.beginPath();
-        context.moveTo(startX, startY - 15);
-        context.lineTo(context.canvas.width - 30, startY - 15);
+        context.moveTo(startX, startY - 20);
+        context.lineTo(context.canvas.width - 30, startY - 20);
         context.stroke();
       }
     });


### PR DESCRIPTION
Fixes #90

Increase vertical spacing between ranking rows to show dashed lines correctly.

* Adjust the `startY` increment from 30 to 40 pixels in the `render` method.
* Modify the position of the dashed line to account for the increased spacing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/91?shareId=f9c3e6c4-0dd9-4174-96c9-d303890b8e18).