### PR TITLE
Add API call implementation for authentication options

### DIFF
--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -11,7 +11,7 @@ export const WEBSOCKET_BASE_URL =
   API_WS_PROTOCOL + API_HOSTNAME + API_PATH + API_VERSION;
 
 export const VERSION_ENDPOINT = "/version";
-export const AUTH_OPTIONS_ENDPOINT = "/passkey/registration-options";
+export const REGISTRATION_OPTIONS_ENDPOINT = "/passkey/registration-options";
 export const VERIFY_REGISTRATION_RESPONSE_ENDPOINT =
   "/passkey/verify-registration-response";
 export const VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT =
@@ -27,4 +27,4 @@ export const MATCHES_REMOVE_ENDPOINT = "/matches/remove";
 export const SCOREBOARD_PATH = "/scoreboard";
 export const SCOREBOARD_SAVE_SCORE_PATH = `${SCOREBOARD_PATH}/saveScore`;
 export const SCOREBOARD_GET_RANKING_PATH = `${SCOREBOARD_PATH}/getRanking`;
-export const AUTH_OPTIONS_ENDPOINT = "/passkeys/authentication-options";
+export const AUTHENTICATION_OPTIONS_ENDPOINT = "/passkeys/authentication-options";

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -27,3 +27,4 @@ export const MATCHES_REMOVE_ENDPOINT = "/matches/remove";
 export const SCOREBOARD_PATH = "/scoreboard";
 export const SCOREBOARD_SAVE_SCORE_PATH = `${SCOREBOARD_PATH}/saveScore`;
 export const SCOREBOARD_GET_RANKING_PATH = `${SCOREBOARD_PATH}/getRanking`;
+export const AUTH_OPTIONS_ENDPOINT = "/passkeys/authentication-options";

--- a/src/interfaces/response/auth-options-response.ts
+++ b/src/interfaces/response/auth-options-response.ts
@@ -1,5 +1,3 @@
-// PublicKeyCredentialRequestOptions
-
 export interface AuthOptionsResponse {
   challenge: string;
   rp: {
@@ -17,4 +15,9 @@ export interface AuthOptionsResponse {
   }>;
   timeout: number;
   attestation: AttestationConveyancePreference | undefined;
+  allowCredentials: Array<{
+    type: "public-key";
+    id: string;
+    transports: string[];
+  }>;
 }

--- a/src/interfaces/response/auth-options-response.ts
+++ b/src/interfaces/response/auth-options-response.ts
@@ -15,9 +15,4 @@ export interface AuthOptionsResponse {
   }>;
   timeout: number;
   attestation: AttestationConveyancePreference | undefined;
-  allowCredentials: Array<{
-    type: "public-key";
-    id: string;
-    transports: string[];
-  }>;
 }

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -9,10 +9,10 @@ import {
   VERSION_ENDPOINT,
   SCOREBOARD_SAVE_SCORE_PATH,
   SCOREBOARD_GET_RANKING_PATH,
-  AUTH_OPTIONS_ENDPOINT as REGISTRATION_OPTIONS_ENDPOINT,
+  REGISTRATION_OPTIONS_ENDPOINT,
   VERIFY_REGISTRATION_RESPONSE_ENDPOINT,
   VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,
-  AUTH_OPTIONS_ENDPOINT,
+  AUTHENTICATION_OPTIONS_ENDPOINT
 } from "../constants/api-constants.js";
 import { FindMatchesResponse as FindMatchesResponse } from "../interfaces/response/find-matches-response.js";
 import { MessagesResponse } from "../interfaces/response/messages-response.js";
@@ -73,7 +73,7 @@ export class ApiService {
   public async getAuthenticationOptions(
     username: string
   ): Promise<AuthOptionsResponse> {
-    const response = await fetch(API_BASE_URL + AUTH_OPTIONS_ENDPOINT, {
+    const response = await fetch(API_BASE_URL + AUTHENTICATION_OPTIONS_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -12,6 +12,7 @@ import {
   AUTH_OPTIONS_ENDPOINT as REGISTRATION_OPTIONS_ENDPOINT,
   VERIFY_REGISTRATION_RESPONSE_ENDPOINT,
   VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,
+  AUTH_OPTIONS_ENDPOINT,
 } from "../constants/api-constants.js";
 import { FindMatchesResponse as FindMatchesResponse } from "../interfaces/response/find-matches-response.js";
 import { MessagesResponse } from "../interfaces/response/messages-response.js";
@@ -65,6 +66,29 @@ export class ApiService {
 
     const authOptions = await response.json();
     console.log("Auth options", authOptions);
+
+    return authOptions;
+  }
+
+  public async getAuthenticationOptions(
+    username: string
+  ): Promise<AuthOptionsResponse> {
+    const response = await fetch(API_BASE_URL + AUTH_OPTIONS_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username,
+      }),
+    });
+
+    if (response.ok === false) {
+      throw new Error("Failed to fetch authentication options");
+    }
+
+    const authOptions = await response.json();
+    console.log("Authentication options", authOptions);
 
     return authOptions;
   }

--- a/src/services/passkey-service.ts
+++ b/src/services/passkey-service.ts
@@ -21,7 +21,7 @@ export class PasskeyService {
         try {
           // Retrieve authentication options for `navigator.credentials.get()`
           // from your server.
-          const authOptions = await this.apiService.getRegistrationOptions("");
+          const authOptions = await this.apiService.getAuthenticationOptions("");
           // This call to `navigator.credentials.get()` is "set and forget."
           // The Promise will only resolve if the user successfully interacts
           // with the browser's autofill UI to select a passkey.


### PR DESCRIPTION
Fixes #93

Add API call implementation for authentication options.

* Add `AUTH_OPTIONS_ENDPOINT` constant in `src/constants/api-constants.ts`.
* Add `allowCredentials` property to `AuthOptionsResponse` interface in `src/interfaces/response/auth-options-response.ts`.
* Add `getAuthenticationOptions` method to `ApiService` class in `src/services/api-service.ts`.
* Update `showAutofillUI` method in `src/services/passkey-service.ts` to use `getAuthenticationOptions` instead of `getRegistrationOptions`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/94?shareId=54bb6eac-852b-4b33-92c9-2a52de2355e9).