### PR TITLE
Improve npm scripts

### DIFF
--- a/.github/workflows/deploy-page.yml
+++ b/.github/workflows/deploy-page.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Bundle project
         run: npm run bundle
 
-      - name: Build project
-        run: npm run build
-
       - name: Upload artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "cd static && tsc",
-    "dev": "npm-run-all --parallel http-server tsc-watch",
+    "dev": "npm-run-all --parallel http-server esbuild --watch",
     "lint": "eslint -c eslint.config.js",
     "http-server": "http-server -c-1 ./static",
-    "tsc-watch": "cd static && tsc --watch",
-    "bundle": "esbuild src/main.ts --bundle --outfile=static/js/bundle.js"
+    "bundle": "esbuild src/main.ts --bundle --outfile=static/js/bundle.js --watch"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Fixes #96

Improve npm scripts

* Remove the `build` script from the `package.json` file.
* Update the `dev` script to use `esbuild --watch` and `http-server`.
* Add the `--watch` flag to the `bundle` script in the `package.json` file.
* Remove the `tsc-watch` script from the `package.json` file.
* Remove the step that runs the `build` script in the `.github/workflows/deploy-page.yml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/97?shareId=a403cd20-abc1-4b72-be59-76ff91e9a665).