### PR TITLE
Serialize credential data in credential service before verifying

### DIFF
--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -75,7 +75,7 @@ export class ApiService {
 
   public async verifyRegistrationResponse(
     username: string,
-    credential: Credential
+    credential: any
   ): Promise<AuthenticationResponse> {
     const response = await fetch(
       API_BASE_URL + VERIFY_REGISTRATION_RESPONSE_ENDPOINT,
@@ -129,7 +129,7 @@ export class ApiService {
 
   public async verifyAuthenticationResponse(
     requestId: string,
-    credential: Credential
+    credential: any
   ): Promise<AuthenticationResponse> {
     const response = await fetch(
       API_BASE_URL + VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,

--- a/src/services/credential-service.ts
+++ b/src/services/credential-service.ts
@@ -90,11 +90,13 @@ export class CredentialService {
       throw new Error("User canceled credential creation");
     }
 
-    alert(`Credential created: ${JSON.stringify(credential)}`); // Pa63e
+    alert(`Credential created: ${JSON.stringify(credential)}`);
+
+    const serializedCredential = this.serializeCredential(credential);
 
     const response = await this.apiService.verifyRegistrationResponse(
       name,
-      credential
+      serializedCredential
     );
 
     this.handleAuthenticationResponse(response);
@@ -116,11 +118,13 @@ export class CredentialService {
       throw new Error("User canceled credential request");
     }
 
-    alert(`Credential used: ${JSON.stringify(credential)}`); // P7ed6
+    alert(`Credential used: ${JSON.stringify(credential)}`);
+
+    const serializedCredential = this.serializeCredential(credential);
 
     const response = await this.apiService.verifyAuthenticationResponse(
       this.requestId,
-      credential
+      serializedCredential
     );
 
     this.handleAuthenticationResponse(response);
@@ -145,5 +149,27 @@ export class CredentialService {
 
     const localEvent = new LocalEvent(EventType.ServerAuthenticated, null);
     this.eventProcessorService.addLocalEvent(localEvent);
+  }
+
+  private serializeCredential(credential: PublicKeyCredential): any {
+    return {
+      id: credential.id,
+      type: credential.type,
+      rawId: btoa(String.fromCharCode(...new Uint8Array(credential.rawId))),
+      response: {
+        clientDataJSON: btoa(
+          String.fromCharCode(...new Uint8Array(credential.response.clientDataJSON))
+        ),
+        authenticatorData: credential.response.authenticatorData
+          ? btoa(String.fromCharCode(...new Uint8Array(credential.response.authenticatorData)))
+          : null,
+        signature: credential.response.signature
+          ? btoa(String.fromCharCode(...new Uint8Array(credential.response.signature)))
+          : null,
+        userHandle: credential.response.userHandle
+          ? btoa(String.fromCharCode(...new Uint8Array(credential.response.userHandle)))
+          : null,
+      },
+    };
   }
 }

--- a/src/services/credential-service.ts
+++ b/src/services/credential-service.ts
@@ -153,7 +153,7 @@ export class CredentialService {
 
   private serializeCredential(credential: PublicKeyCredential): any {
     return {
-      id: credential.id,
+      id: this.base64UrlEncode(credential.id),
       type: credential.type,
       rawId: btoa(String.fromCharCode(...new Uint8Array(credential.rawId))),
       response: {
@@ -171,5 +171,9 @@ export class CredentialService {
           : null,
       },
     };
+  }
+
+  private base64UrlEncode(input: string): string {
+    return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
   }
 }

--- a/src/services/credential-service.ts
+++ b/src/services/credential-service.ts
@@ -90,8 +90,6 @@ export class CredentialService {
       throw new Error("User canceled credential creation");
     }
 
-    alert(`Credential created: ${JSON.stringify(credential)}`);
-
     const serializedCredential = this.serializeCredential(credential);
 
     const response = await this.apiService.verifyRegistrationResponse(
@@ -117,8 +115,6 @@ export class CredentialService {
     if (credential === null) {
       throw new Error("User canceled credential request");
     }
-
-    alert(`Credential used: ${JSON.stringify(credential)}`);
 
     const serializedCredential = this.serializeCredential(credential);
 


### PR DESCRIPTION
Fixes #102

Serialize credential data in the credential service before verifying.

* Add `serializeCredential` helper function to `CredentialService` class in `src/services/credential-service.ts`.
* Update `registerCredential` and `useCredential` methods in `src/services/credential-service.ts` to use `serializeCredential` before passing the credential to the API service.
* Update `verifyRegistrationResponse` and `verifyAuthenticationResponse` methods in `src/services/api-service.ts` to receive serialized credential data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/multiplayer-game/pull/103?shareId=2b568b33-8626-42c9-9ac0-14853e9229c5).